### PR TITLE
chore(providers): update google and google beta version

### DIFF
--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -3,11 +3,11 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 4, < 5"
+      version = ">= 5, < 8"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4, < 5"
+      version = ">= 5, < 8"
     }
   }
 

--- a/examples/remote/versions.tf
+++ b/examples/remote/versions.tf
@@ -3,11 +3,11 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 4, < 5"
+      version = ">= 5, < 8"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4, < 5"
+      version = ">= 5, < 8"
     }
   }
 

--- a/versions.tf
+++ b/versions.tf
@@ -3,11 +3,11 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 4, < 8"
+      version = ">= 5, < 8"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4, < 8"
+      version = ">= 5, < 8"
     }
   }
 


### PR DESCRIPTION
This pull request updates the required provider versions for Google Cloud in the Terraform configuration to ensure compatibility with newer features and improvements.

Provider version updates:

* Increased the minimum required version for both the `google` and `google-beta` providers from `>= 4` to `>= 5` in `versions.tf`.